### PR TITLE
Fix typo in fishrc comment

### DIFF
--- a/fishrc
+++ b/fishrc
@@ -28,7 +28,7 @@ switch (uname)
                 # Commands to run in interactive sessions can go here
                 eval "$(/opt/homebrew/bin/brew shellenv)"
 
-                # evaluate wether this works better than the auto-start
+                # evaluate whether this works better than the auto-start
                 # script below
                 # eval zellij attach --create main
                 eval (zellij setup --generate-auto-start fish | string collect)


### PR DESCRIPTION
## Summary
- fix typo in fishrc comment for auto-start evaluation

## Testing
- `fish -n fishrc`


------
https://chatgpt.com/codex/tasks/task_e_68a5b06f94ec8327bf8d895ce1a52251