### PR TITLE
Fix Rust plugin echo message

### DIFF
--- a/bin/tmp/tmp_plugin_rust.sh
+++ b/bin/tmp/tmp_plugin_rust.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function handle_rust() {
-    echo "Handling Zig language" >&2
+    echo "Handling Rust language" >&2
 
     TARGET_DIR=$1
     DIRECTORY_CREATED=$2


### PR DESCRIPTION
## Summary
- Correct rust plugin output from Zig to Rust

## Testing
- `shellcheck bin/tmp/tmp_plugin_rust.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5b076e3ec83278c80e538cd89341a