### PR TITLE
fix: clarify rust plugin behavior

### DIFF
--- a/bin/tmp/tmp_plugin_rust.sh
+++ b/bin/tmp/tmp_plugin_rust.sh
@@ -8,7 +8,7 @@ function handle_rust() {
 
     # If DIRECTORY_CREATED is 1, the directory already exists
     # As we don't want to mess with existing directories,
-    # we don't create create main.go or run go mod init
+    # existing directories skip creating main.rs and running cargo init
     if [ "$DIRECTORY_CREATED" -eq 0 ]; then
         FILE_OPEN="$TARGET_DIR/src/main.rs"
         cd "$TARGET_DIR" && cargo init --bin && cd "$_PWD" || exit


### PR DESCRIPTION
## Summary
- clarify comment for Rust plugin about skipping main.rs creation and cargo init when directory already exists

## Testing
- `shellcheck bin/tmp/tmp_plugin_rust.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5b176197c83278ac97cc18f02d904